### PR TITLE
Add pyproject.toml for Custom Node Registry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+[project]
+name = "ai-photography-toolkit"
+description = "A collection of AI-powered photography and image generation tools for ComfyUI, featuring the SID_AIPromptGenerator node that uses Anthropic's Claude API to analyze images and generate optimized prompts for various image generation models."
+version = "1.0.0"
+license = {file = "LICENSE"} 
+# classifiers = [
+#     # For OS-independent nodes (works on all operating systems)
+#     "Operating System :: OS Independent",
+#
+#     # OR for OS-specific nodes, specify the supported systems:
+#     "Operating System :: Microsoft :: Windows",  # Windows specific
+#     "Operating System :: POSIX :: Linux",  # Linux specific
+#     "Operating System :: MacOS",  # macOS specific
+#
+#     # GPU Accelerator support. Pick the ones that are supported by your extension.
+#     "Environment :: GPU :: NVIDIA CUDA",    # NVIDIA CUDA support
+#     "Environment :: GPU :: AMD ROCm",       # AMD ROCm support
+#     "Environment :: GPU :: Intel Arc",      # Intel Arc support
+#     "Environment :: NPU :: Huawei Ascend",  # Huawei Ascend support
+#     "Environment :: GPU :: Apple Metal",    # Apple Metal support
+# ]
+
+dependencies = ["# ComfyUI-AI-Photography-Toolkit Dependencies", "# Anthropic Claude API", "anthropic>=0.39.0", "# Image processing (usually included with ComfyUI, but listed for completeness)", "pillow>=10.0.0", "numpy>=1.24.0", "# Future dependencies for additional nodes", "# openai>=1.0.0  # For OpenAI integration (future)"]
+
+[project.urls]
+Repository = "https://github.com/slahiri/ComfyUI-AI-Photography-Toolkit"
+#  Used by Comfy Registry https://registry.comfy.org
+Documentation = "https://github.com/slahiri/ComfyUI-AI-Photography-Toolkit/wiki"
+"Bug Tracker" = "https://github.com/slahiri/ComfyUI-AI-Photography-Toolkit/issues"
+
+[tool.comfy]
+PublisherId = ""
+DisplayName = "ComfyUI-AI-Photography-Toolkit"
+Icon = ""
+includes = [] 
+# "requires-comfyui" = ">=1.0.0"  # ComfyUI version compatibility
+


### PR DESCRIPTION
Hey! My name is Robin and I'm from [comfy-org](https://comfy.org/)! We would love to have you join the Comfy Registry, a public collection of custom nodes which lets authors publish nodes by version and automate testing against existing workflows. 

The registry is already integrated with ComfyUI-Manager, and we want it to be the default place users install nodes from eventually. We do a security-scan of every node to improve safety. Feel free to read up more on the registry [here](https://docs.comfy.org/registry/overview#introduction)

- The documentation scaffolding? You can just add the example markdown [here](https://docs.comfy.org/custom-nodes/help_page#setup) into web/docs/MyNode.md

Action Required:

- [ ] Go to the [registry](https://registry.comfy.org). Login and create a publisher id (everything after the `@` sign on your registry profile). 
- [ ] Add the publisher id into the pyproject.toml file.
- [ ] Merge the separate Github Actions PR, then merge this PR.

If you want to publish the node manually, [install the cli](https://docs.comfy.org/comfy-cli/getting-started#install-cli) by running `pip install comfy-cli`, then run `comfy node publish`

Otherwise, if you have any questions, please message me on discord at robinken or join our [server](https://discord.com/invite/comfyorg)!